### PR TITLE
Fix NullReferenceExceptions

### DIFF
--- a/Assets/Scripts/Pathfinding/Path_RoomGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_RoomGraph.cs
@@ -84,7 +84,7 @@ public class Path_RoomGraph
             Tile[] neighbours = t.GetNeighbours();
             foreach (Tile t2 in neighbours)
             {
-                if (t2 != null && t2.Room != null)
+                if (t2 == null || t2.Room == null)
                 {
                     continue;
                 }


### PR DESCRIPTION
The test at Path_RoomGraph.cs:87 seems to be backwards and I'm getting exceptions from a couple lines further down when trying to access a null value.